### PR TITLE
デプロイ用Docker環境構築

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -21,9 +21,6 @@
   <component name="ChangeListManager">
     <list default="true" id="b4d9944f-f1f8-4042-8914-ea67de2bbbb4" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/Http/Controllers/MyCharacterController.php" beforeDir="false" afterPath="$PROJECT_DIR$/app/Http/Controllers/MyCharacterController.php" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/database/migrations/2020_10_08_204724_create_user_character.php" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/database/migrations/2020_10_10_235608_create_user_character.php" beforeDir="false" afterPath="$PROJECT_DIR$/database/migrations/2020_10_10_235608_create_user_character.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM php:7.4-fpm
+COPY php.ini /usr/local/etc/php/
+
+RUN apt-get update \
+  && apt-get install -y libzip-dev \
+  && apt-get install -y zlib1g-dev mariadb-client \
+  && docker-php-ext-install zip pdo_mysql
+
+#Composer install
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+ENV COMPOSER_HOME /composer
+
+ENV PATH $PATH:/composer/vendor/bin
+
+WORKDIR /var/www/html
+
+COPY . .
+
+EXPOSE 8000
+
+RUN composer install \
+    && composer install --no-progress --no-dev \
+    && php artisan config:clear
+
+CMD ["php","artisan","serve","--host","0.0.0.0", "--port", "8000"]

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,5 @@
+[Date]
+date.timezone = "Asia/Tokyo"
+[mbstring]
+mbstring.internal_encoding = "UTF-8"
+mbstring.language = "Japanese"


### PR DESCRIPTION
## why
- デプロイの簡易化のため、Dockerを使ってデプロイできるようにしたい
  - terraformも勉強したかった

## what
- dockerfileでdocker環境作成
- php.iniなどの必要な補助設定も追加
- 8000番でphp artisan serve

参考
https://qiita.com/A-Kira/items/1c55ef689c0f91420e81