### PR TITLE
ログインが必要なエンドポイントを認証必須に

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -22,8 +22,8 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::get('/gacha/platinum',[GachaController::class, 'platinum']);
-Route::get('/myCharacters', [MyCharacterController::class, 'myCharacters']);
+Route::get('/gacha/platinum',[GachaController::class, 'platinum'])->middleware('auth:api');;
+Route::get('/myCharacters', [MyCharacterController::class, 'myCharacters'])->middleware('auth:api');
 Route::post('/register', [RegisterController::class, 'register']);
 
 Route::group([
@@ -39,3 +39,7 @@ Route::group([
     Route::post('me', 'AuthController@me');
 
 });
+
+Route::get('/', function () {
+    return response()->json(['error' => 'Unauthenticated.'], 401);
+})->name('login');

--- a/tests/Feature/GachaTest.php
+++ b/tests/Feature/GachaTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class GachaTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function testNotAuthenticatedUser()
+    {
+        $response = $this->get('/api/gacha/platinum');
+
+        $response->assertStatus(302);
+    }
+}

--- a/tests/Feature/MyCharactersTest.php
+++ b/tests/Feature/MyCharactersTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class MyCharactersTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function testNotAuthenticatedUser()
+    {
+        $response = $this->get('/api/myCharacters/');
+
+        $response->assertStatus(302);
+    }
+}


### PR DESCRIPTION
## why
- ログインが必要なエンドポイントがログインなしでもアクセスできていた
  - エラーをちゃんとクライアント側が認識することができない


## what
- 認証に失敗していれば、リダイレクトして401を返す
  - とりあえず、302でリダイレクトを受け取れればクライアント側で一旦エラーハンドリングできるのでこれでよしとする

## ref
- https://qiita.com/tomoeine/items/40a966bf3801633cf90f#guard%E3%81%A3%E3%81%A6%E3%81%A9%E3%81%86%E3%82%84%E3%81%A3%E3%81%A6%E4%BD%BF%E3%81%86%E3%82%93%E3%81%A0%E3%81%A3%E3%81%9F%E3%81%A3%E3%81%91%E3%81%8A%E3%81%95%E3%82%89%E3%81%84
- https://medium.com/@agoalofalife/laravel-route-login-not-defined-oops-f64b76060e1d
- https://readouble.com/laravel/7.x/ja/testing.html