### PR TITLE
認証失敗時のリダイレクト後のテスト追加

### DIFF
--- a/tests/Feature/GachaTest.php
+++ b/tests/Feature/GachaTest.php
@@ -13,7 +13,7 @@ class GachaTest extends TestCase
      *
      * @return void
      */
-    public function testNotAuthenticatedUser()
+    public function testNotAuthenticated()
     {
         $response = $this->get('/api/gacha/platinum');
         $response->assertStatus(302);

--- a/tests/Feature/GachaTest.php
+++ b/tests/Feature/GachaTest.php
@@ -16,7 +16,9 @@ class GachaTest extends TestCase
     public function testNotAuthenticatedUser()
     {
         $response = $this->get('/api/gacha/platinum');
-
         $response->assertStatus(302);
+
+        $response = $this->followingRedirects()->get('/api/gacha/platinum');
+        $response->assertStatus(401);
     }
 }

--- a/tests/Feature/MyCharactersTest.php
+++ b/tests/Feature/MyCharactersTest.php
@@ -13,7 +13,7 @@ class MyCharactersTest extends TestCase
      *
      * @return void
      */
-    public function testNotAuthenticatedUser()
+    public function testNotAuthenticated()
     {
         $response = $this->get('/api/myCharacters/');
         $response->assertStatus(302);

--- a/tests/Feature/MyCharactersTest.php
+++ b/tests/Feature/MyCharactersTest.php
@@ -16,7 +16,9 @@ class MyCharactersTest extends TestCase
     public function testNotAuthenticatedUser()
     {
         $response = $this->get('/api/myCharacters/');
-
         $response->assertStatus(302);
+
+        $response = $this->followingRedirects()->get('/api/myCharacters/');
+        $response->assertStatus(401);
     }
 }


### PR DESCRIPTION
## why
- リダイレクト後のテストがなかったため、正しい挙動をしているか完全に確認できていなかった


## what
- api/myCharactersとapi/gacha/platinumのリダイレクト後のテストを書いた

## 参考
- https://www.366service.com/jp/qa/6f00546f3276f443fa518254edba9acc