### PR TITLE
ユーザデータ取得APIのHTTPメソッド修正

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -36,8 +36,7 @@ Route::group([
     Route::post('login', 'AuthController@login');
     Route::post('logout', 'AuthController@logout');
     Route::post('refresh', 'AuthController@refresh');
-    Route::post('me', 'AuthController@me');
-
+    Route::get('me', 'AuthController@me');
 });
 
 Route::get('/', function () {

--- a/tests/Feature/MeTest.php
+++ b/tests/Feature/MeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class MeTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function testNotAuthenticated()
+    {
+        $response = $this->get('/api/auth/me');
+        $response->assertStatus(302);
+
+        $response = $this->followingRedirects()->get('/api/auth/me');
+        $response->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## why
- 取得系なのでPOSTよりGETの方がわかりやすい

## what
- api/auth/meをPOSTからGETに変更
- api/auth/meの非認証時のテスト追加