### PR TITLE
ガチャで重複していなければ保存する

### DIFF
--- a/app/Http/Controllers/GachaController.php
+++ b/app/Http/Controllers/GachaController.php
@@ -8,12 +8,13 @@ use Illuminate\Support\Facades\Auth;
 class GachaController extends Controller
 {
    public function platinum(){
-       $user = Auth::user();
-       $characters = UserCharacter::query()->where('user_id', $user->id)->get();
-       $charactersRef = $user->characters();
        $randomCharacterId = random_int(1, 5);
        $newCharacter = new UserCharacter(['characterId' => $randomCharacterId]);
-       if($characters->count() == 0){
+
+       $user = Auth::user();
+       $characters = UserCharacter::query()->where('user_id', $user->id)->get();
+       if(!$characters->contains($randomCharacterId)){
+           $charactersRef = $user->characters();
            $charactersRef->save($newCharacter);
        }
        return response()->json(["characterId"=> $newCharacter->characterId]);


### PR DESCRIPTION
## why
-  なぜかキャラクターが０個の時しかガチャ結果を保存しないようになっていた

## what
- ガチャ結果が手持ちのキャラと重複していなければ、手持ちのキャラとして保存するように変更