### PR TITLE
クエスト結果一覧API

### DIFF
--- a/app/Http/Controllers/QuestController.php
+++ b/app/Http/Controllers/QuestController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class QuestController extends Controller
+{
+    public function index(){
+        $user = Auth()->user();
+
+    }
+}

--- a/app/Http/Controllers/QuestResultController.php
+++ b/app/Http/Controllers/QuestResultController.php
@@ -15,7 +15,9 @@ class QuestResultController extends Controller
         $isCleared = $request->input('isCleared');
         $oldQuestResults = QuestResult::query()->where('questId', $questId)->where('user_id', Auth::user()->id);
         if ($oldQuestResults->count() == 0) {
-            $questResult = QuestResult::query()->create(['user_id' => Auth::user()->id, 'questId' => $questId, 'isCleared' => $isCleared]);
+            // $questResult = QuestResult::query()->create(['user_id' => Auth::user()->id, 'questId' => $questId, 'isCleared' => $isCleared]);
+            $questResult = new QuestResult(['user_id' => Auth::user()->id, 'questId' => $questId, 'isCleared' => $isCleared]);
+            Auth::user()->questResults()->save($questResult);
             return response()->json(['user_id' => $questResult->user()[0]->id, "questId" => $questResult->questId, 'isCleared' => $questResult->isCleared]);
         } else {
             $oldQuestResult = $oldQuestResults->get()->first();
@@ -26,5 +28,10 @@ class QuestResultController extends Controller
                 return response()->json(['user_id' => Auth::user()->id, "questId" => $questId, 'isCleared' => $isCleared]);
             }
         }
+    }
+
+    public function index(){
+        $questResults = Auth()->user()->questResults()->get();
+        return response()->json(['questResults'=>$questResults]);
     }
 }

--- a/app/QuestResult.php
+++ b/app/QuestResult.php
@@ -15,4 +15,8 @@ class QuestResult extends Model
         'questId',
         'isCleared',
     ];
+
+    protected $casts = [
+        'isCleared' => 'boolean'
+    ];
 }

--- a/app/User.php
+++ b/app/User.php
@@ -44,6 +44,10 @@ class User extends Authenticatable implements JWTSubject
         return  $this->hasMany('App\UserCharacter');
     }
 
+    public function questResults(){
+        return $this->hasMany('App\QuestResult');
+    }
+
     // Rest omitted for brevity
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -46,3 +46,4 @@ Route::get('/', function () {
 
 Route::post('/questResult/updateQuestClearResult', [QuestResultController::class, 'updateQuestClearStatus'])->middleware('auth:api');
 // Route::post('/questResult/updateQuestClearResult', [QuestResultController::class, 'updateQuestClearStatus']);
+Route::get('/questResult/index', [QuestResultController::class, 'index'])->middleware('auth:api');

--- a/tests/Feature/QuestResultTest.php
+++ b/tests/Feature/QuestResultTest.php
@@ -11,6 +11,7 @@ use Tests\TestCase;
 
 class QuestResultTest extends TestCase
 {
+    use RefreshDatabase;
     /**
      * A basic feature test example.
      *

--- a/tests/Feature/QuestResultTest.php
+++ b/tests/Feature/QuestResultTest.php
@@ -48,4 +48,12 @@ class QuestResultTest extends TestCase
         $questResult = QuestResult::query()->where('user_id',$user->id)->where('questId',1)->get()->first();
         assert($questResult->isCleared, true);
     }
+
+    public function testGetQuestResults(){
+        $user = factory(User::class)->create();
+        $response = $this->actingAs($user)->postJson('/api/questResult/updateQuestClearResult', ['questId'=>1, 'isCleared'=>false]);
+        $response->assertJson(['user_id'=>$user->id,'questId'=>1,'isCleared'=>false]);
+        $response2 = $this->actingAs($user)->getJson('api/questResult/index');
+        $response2->assertJson(['questResults' => ['0' => ['user_id' => $user->id, 'questId'=> 1, 'isCleared' => false]]]);
+    }
 }


### PR DESCRIPTION
## why
- クエストの結果一覧をクライアント側で取得したい


## what
- クエスト結果一覧のAPIを作成

```
{
  "questResults": [
    {
      "id": 9,
      "created_at": "2020-11-10T19:54:10.000000Z",
      "updated_at": "2020-11-10T19:54:10.000000Z",
      "questId": 1,
      "isCleared": true,
      "user_id": 1
    },
    {
      "id": 20,
      "created_at": "2020-11-11T18:57:53.000000Z",
      "updated_at": "2020-11-11T18:57:53.000000Z",
      "questId": 2,
      "isCleared": true,
      "user_id": 1
    },
    {
      "id": 23,
      "created_at": "2020-11-12T03:11:58.000000Z",
      "updated_at": "2020-11-12T03:16:23.000000Z",
      "questId": 3,
      "isCleared": true,
      "user_id": 1
    }
  ]
}
```