### PR TITLE
ガチャロジックをハリボテから本物に変更

### DIFF
--- a/app/Character.php
+++ b/app/Character.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Character extends Model
+{
+    protected $fillable = [
+        'name'
+    ];
+}

--- a/app/Http/Controllers/Gacha/GachaController.php
+++ b/app/Http/Controllers/Gacha/GachaController.php
@@ -5,11 +5,13 @@ namespace App\Http\Controllers\Gacha;
 use App\UserCharacter;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\Controller;
+use Packages\gacha\PlatinumGacha;
 
 class GachaController extends Controller
 {
    public function platinum(){
-       $randomCharacterId = random_int(1, 5);
+       $gacha = new PlatinumGacha();
+       $randomCharacterId = $gacha->draw();
        $newCharacter = new UserCharacter(['characterId' => $randomCharacterId]);
 
        $user = Auth::user();

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     },
     "autoload": {
         "psr-4": {
-            "App\\": "app/"
+            "App\\": "app/",
+            "Packages\\": "packages/"
         },
         "classmap": [
             "database/seeds",

--- a/database/migrations/2020_12_15_193228_create_characters_table.php
+++ b/database/migrations/2020_12_15_193228_create_characters_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCharactersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('characters', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('characters');
+    }
+}

--- a/database/migrations/2020_12_15_193348_add_name_column_to_characters.php
+++ b/database/migrations/2020_12_15_193348_add_name_column_to_characters.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddNameColumnToCharacters extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('characters', function (Blueprint $table) {
+            $table->string('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('characters', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+    }
+}

--- a/packages/character/CharacterRepository.php
+++ b/packages/character/CharacterRepository.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Packages\character;
+
+use \App\Character;
+
+class CharacterRepository
+{
+    public function countAll()
+    {
+        return Character::all()->count();
+    }
+}

--- a/packages/gacha/PlatinumGacha.php
+++ b/packages/gacha/PlatinumGacha.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Packages\gacha;
+
+use Packages\character\CharacterRepository;
+
+class PlatinumGacha{
+    public function draw(){
+        return random_int(1, $this->getAllCharacterNumber());
+    }
+
+    public function getAllCharacterNumber(){
+        $characterRepository = new CharacterRepository();
+        return $characterRepository->countAll();
+    }
+}

--- a/tests/Feature/GachaTest.php
+++ b/tests/Feature/GachaTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 use App\User;
+use App\Character;
 
 class GachaTest extends TestCase
 {
@@ -28,9 +29,14 @@ class GachaTest extends TestCase
         $user = factory(User::class)->create();
         $this->be($user);
 
+        $character1 = new Character(['id'=>1, 'name'=>'赤ホクマ']);
+        $character2 = new Character(['id'=>2, 'name'=>'青ホクマ']);
+        $character1->save();
+        $character2->save();
+
         $response = $this->get('api/gacha/platinum');
         $response->assertStatus(200);
-        $expectedGachaResultRange = range(1,5);
+        $expectedGachaResultRange = range(1,2);
         $this->assertTrue(in_array($response['characterId'], $expectedGachaResultRange, true));
     }
 }


### PR DESCRIPTION
## why
- ガチャロジックが1-5のキャラクター番号を返すハリボテだった
- そもそもキャラクターデータすら用意されていない、ただのID

## what
- まずキャラクターモデルCharacterを作成
  - とりあえず、id, name, timestampのみ
- ガチャのロジックを存在するキャラクターから一つを選ぶように変更
  - とりあえず、idを選ぶのではなく、randint(1, 数)で出している