### PR TITLE
Story progressがまだ存在しない場合への対応

### DIFF
--- a/app/Http/Controllers/StoryProgress/StoryProgressController.php
+++ b/app/Http/Controllers/StoryProgress/StoryProgressController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\StoryProgress;
 
+use App\Story;
 use App\StoryProgress;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
@@ -22,7 +23,11 @@ class StoryProgressController extends Controller
     public function updateStoryProgress(Request $request){
         $storyProgress = auth()->user()->storyProgress()->first();
         $readStoryId = $request->json('read_story_id');
-        if($readStoryId == $storyProgress->latest_readable){
+        if(is_null($storyProgress) && $readStoryId == 1){
+            $newStoryProgress = StoryProgress::query()->create(['user_id'=>auth()->user()->id, 'latest_readable'=>2]);
+            return response()->json(['latest_readable'=>$newStoryProgress->latest_readable]);
+        }
+        else if(!is_null($storyProgress) && $readStoryId == $storyProgress->latest_readable){
             $storyProgress->latest_readable = $storyProgress->latest_readable + 1;
             $storyProgress->save();
             return response()->json(['latest_readable'=> $storyProgress->latest_readable]);

--- a/app/Http/Controllers/StoryProgress/StoryProgressController.php
+++ b/app/Http/Controllers/StoryProgress/StoryProgressController.php
@@ -12,7 +12,11 @@ class StoryProgressController extends Controller
 {
     public function getLatestReadableId(){
         $storyProgress = auth()->user()->storyProgress()->first();
-        return response()->json(['latest_readable'=> $storyProgress->latest_readable]);
+        if(is_null($storyProgress)){
+            return response()->json(['latest_readable'=>1]);
+        }else{
+            return response()->json(['latest_readable'=> $storyProgress->latest_readable]);
+        }
     }
 
     public function updateStoryProgress(Request $request){

--- a/tests/Feature/StoryProgressTest.php
+++ b/tests/Feature/StoryProgressTest.php
@@ -39,6 +39,25 @@ class StoryProgressTest extends TestCase
         $this->assertDatabaseHas('story_progress', ['user_id'=>1, 'latest_readable'=>2]);
     }
 
+    public function testUpdateStoryProgressWhenItDoesNotExistYet(){
+        $user = factory(User::class)->create(['id'=>1]);
+
+        $response = $this->actingAs($user)->postJson('api/auth/updateStoryProgress', ['read_story_id'=>1]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['latest_readable'=>2]);
+        $this->assertDatabaseHas('story_progress', ['user_id'=>1, 'latest_readable'=>2]);
+    }
+
+    public function testUpdateStoryProgressWithBadReadStoryIdWhenItDoesNotExistYet(){
+        $user = factory(User::class)->create(['id'=>1]);
+
+        $response = $this->actingAs($user)->postJson('api/auth/updateStoryProgress', ['read_story_id'=>2]);
+
+        $response->assertStatus(400);
+    }
+
+
     public function testStoryProgressNotExist(){
         $user = factory(User::class)->create(['id'=>1]);
 

--- a/tests/Feature/StoryProgressTest.php
+++ b/tests/Feature/StoryProgressTest.php
@@ -38,4 +38,13 @@ class StoryProgressTest extends TestCase
         $response->assertJson(['latest_readable'=>2]);
         $this->assertDatabaseHas('story_progress', ['user_id'=>1, 'latest_readable'=>2]);
     }
+
+    public function testStoryProgressNotExist(){
+        $user = factory(User::class)->create(['id'=>1]);
+
+        $response = $this->actingAs($user)->getJson('api/auth/storyProgress');
+
+        $response->assertStatus(200);
+        $response->assertJson(['latest_readable'=>1]);
+    }
 }


### PR DESCRIPTION
## why
StoryProgress関連のエンドポイントでStoryProgressが存在しない場合にエラーになっていた


## what
- Get: StoryProgressが存在しない場合にはlatest_readable: 1を返す
- Post: StoryProgressが存在しない場合には、read_story_id: 1を受け取った時のみlatest_readable: 1で新しいレコードを作成し、latest_readable: 1を返す